### PR TITLE
added a ScrollOff variable to allow for offset scrolling

### DIFF
--- a/resultsview.go
+++ b/resultsview.go
@@ -6,6 +6,8 @@ import (
 	"github.com/nsf/termbox-go"
 )
 
+var ScrollOff = 5
+
 type ResultsView struct {
 	// Array of results to be filtered
 	// initialset ResultArray
@@ -43,7 +45,7 @@ func (r *ResultsView) SelectPrevious() {
 	if r.result_selected > 0 {
 		r.result_selected--
 	}
-	if r.top_result > 0 {
+	if r.top_result > 0 && r.result_selected < r.top_result+ScrollOff {
 		r.top_result--
 		r.bottom_result--
 	}
@@ -53,7 +55,7 @@ func (r *ResultsView) SelectNext() {
 	if r.result_selected < (r.resultCount - 1) {
 		r.result_selected++
 
-		if r.result_selected >= r.bottom_result {
+		if r.result_selected >= r.bottom_result-ScrollOff && r.bottom_result < r.resultCount {
 			r.top_result++
 			r.bottom_result++
 		}


### PR DESCRIPTION
Really love the tool you've made @hugows! Enough that I'd like to use it regularly. I thought that scrolling was acting a little strange so I thought I could make a small improvement!

This change adds the `ScrollOff` integer variable which controls at which point the result list is scrolled.

Right now I have it set to 5. This means that as you `SelectNext()`, the list will not scroll until the `r.bottom_result - 5` is reached. Similarly, as you `SelectPrevious()`, the list will not scroll up until the `r.top_result + 5` is reached.

This makes browsing large lists of files more manageable.
