### PR TITLE
Windows testing

### DIFF
--- a/runcmd_test.go
+++ b/runcmd_test.go
@@ -1,40 +1,35 @@
+// +build !windows
+
 package main
 
 import (
 	"fmt"
 	"testing"
-    "runtime"
 )
-
 
 var FILES = []string{"a", "b", "space jam"}
 
 func TestRuncmdSimple(t *testing.T) {
 
-	if runtime.GOOS != "windows" {
-        if err := runCmdWithArgs("test", "cat $FILES", false, FILES); err != nil {
-            fmt.Println(err)
-    		t.FailNow()
-    	}
-    }
-    var cmd string
-    if runtime.GOOS == "windows" {
-        cmd = "type $FILES"
-    } else {
-        cmd = "cat $FILES"
-    }
-    if err := runCmdWithArgs("test", cmd, true, FILES); err != nil {
-        t.FailNow()
-    }
+	if err := runCmdWithArgs("test", "cat $FILES", false, FILES); err != nil {
+		fmt.Println(err)
+		t.FailNow()
+	}
+
+	// I'm not sure if you wanted both tests ran on linux, and only the latter
+	// in windows.
+
+	cmd := "cat $FILES"
+
+	if err := runCmdWithArgs("test", cmd, true, FILES); err != nil {
+		t.FailNow()
+	}
 }
 
 func TestRuncmdPiped(t *testing.T) {
-    var cmd string
-    cmd = "cat $FILES | wc -l"
+	cmd := "cat $FILES | wc -l"
 
-    if runtime.GOOS != "windows" {
-    	if err := runCmdWithArgs("test", cmd, true, FILES); err != nil {
-    		t.FailNow()
-    	}
-    }
+	if err := runCmdWithArgs("test", cmd, true, FILES); err != nil {
+		t.FailNow()
+	}
 }

--- a/runcmd_windows_test.go
+++ b/runcmd_windows_test.go
@@ -1,0 +1,13 @@
+package main
+
+import "testing"
+
+var FILES = []string{"a", "b", "space jam"}
+
+func TestRuncmdSimple(t *testing.T) {
+	cmd := "type $FILES"
+
+	if err := runCmdWithArgs("test", cmd, true, FILES); err != nil {
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
I changed runcmd_test.go to use a build constraint to only be used when GOOS isn't windows, and I added runcmd_windows_test.go with windows-specific testing. I feel that this helps keep the tests uncluttered by (possibly multiple) operating system checks.
