### PR TITLE
Fixed compilation error in runcmd_test.go, fmt was never used

### DIFF
--- a/runcmd_test.go
+++ b/runcmd_test.go
@@ -2,17 +2,14 @@
 
 package main
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
 var FILES = []string{"a", "b", "space jam"}
 
 func TestRuncmdSimple(t *testing.T) {
 	cmd := "cat $FILES"
 
-	// Test without shell	
+	// Test without shell
 	if err := runCmdWithArgs("test", cmd, false, FILES); err != nil {
 		t.FailNow()
 	}


### PR DESCRIPTION
Recent changes to runcmd_test.go removed calls to `fmt.Println` which caused the file to fail to build.
