### PR TITLE
docs: fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you have Go configured in your system, you should be able to install
 (and update) happyfinder with the command:
 
 ```
-go get -u github.com/hugows/hf
+go install github.com/hugows/hf@latest
 ```
 
 ## Usage


### PR DESCRIPTION
before:

```bash
❯ go get -u github.com/hugows/hf

go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

after:

```bash
❯ go install github.com/hugows/hf@latest

go: downloading github.com/hugows/hf v0.0.0-20150714170739-838e7a642aab
go: finding module for package github.com/nsf/termbox-go
go: downloading github.com/nsf/termbox-go v1.1.1
go: found github.com/nsf/termbox-go in github.com/nsf/termbox-go v1.1.1
go: downloading github.com/mattn/go-runewidth v0.0.9
```